### PR TITLE
WIP: Add initial workflow YAML + scripts.

### DIFF
--- a/.github/workflows/03_publish.yaml
+++ b/.github/workflows/03_publish.yaml
@@ -1,0 +1,97 @@
+name: "3 – Publish Package"
+
+# Trigger the action on push to main
+on:
+  push:
+    tags:
+      - "v*" # Trigger on tags starting with 'v'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  NuGetDirectory: ${{ github.workspace }}/nuget
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Get all history for automatic versioning
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Get latest version from NuGet
+        id: nuget_version
+        run: |
+          $latestVersion = (Invoke-WebRequest -Uri "https://api.nuget.org/v3-flatcontainer/Styra.Opa.AspNetCore/index.json" | ConvertFrom-Json).versions[-1]
+          echo "LATEST_VERSION=$latestVersion" >> $env:GITHUB_OUTPUT
+
+      - name: Get current version
+        id: current_version
+        run: |
+          $currentVersion = (Select-Xml -Path src/Styra.Opa.AspNetCore/Styra.Opa.AspNetCore.csproj -XPath "//PackageVersion").Node.InnerText
+          echo "CURRENT_VERSION=$currentVersion" >> $env:GITHUB_OUTPUT
+
+      #- name: Test
+      #  run: dotnet test --no-restore --verbosity normal
+
+      - name: Pack
+        run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }} --no-build
+
+      - name: Publish NuGet package
+        if: steps.nuget_version.outputs.LATEST_VERSION != steps.current_version.outputs.CURRENT_VERSION
+        run: |
+          foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Filter *.nupkg)) {
+            dotnet nuget push $file --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          }
+        shell: pwsh
+
+  github-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write #  to create release (changesets/action)
+      actions: write #  to create tags (changesets/action)
+      issues: write # to post issue comments (changesets/action)
+      pull-requests: write #  to create pull request (changesets/action)
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Get all history for automatic versioning
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Get current version
+        id: current_version
+        run: |
+          $currentVersion = (Select-Xml -Path src/Styra.Opa.AspNetCore/Styra.Opa.AspNetCore.csproj -XPath "//PackageVersion").Node.InnerText
+          echo "CURRENT_VERSION=$currentVersion" >> $env:GITHUB_OUTPUT
+
+      - name: Generate Styra.Opa.AspNetCore GH release notes
+        run: scripts/latest-release-notes.sh > SDK_RELEASE_NOTES.md
+        env:
+          VERSION: ${{ steps.current_version.outputs.CURRENT_VERSION }}
+
+      - name: Create Styra.Opa.AspNetCore GH release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: SDK_RELEASE_NOTES.md
+          tag_name: ${{ github.ref }}

--- a/scripts/latest-release-notes.sh
+++ b/scripts/latest-release-notes.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -e
+
+OPA_DIR=$(dirname "${BASH_SOURCE}")/..
+CHANGELOG="${OPA_DIR}/CHANGELOG.md"
+
+usage() {
+    echo "latest-release-notes.sh --output=<path>"
+}
+
+OUTPUT=""
+
+for i in "$@"; do
+    case $i in
+    --output=*)
+        OUTPUT="${i#*=}"
+        shift
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+
+if [ -z "${OUTPUT}" ]; then
+    usage
+    exit 1
+fi
+
+# Versions start with a h2 (## <semver>), find the latest two for start and stop
+# positions in the CHANGELOG
+LATEST_VERSION=$(grep '## [0-9]' "${CHANGELOG}" | head -n 1)
+STOP_VERSION=$(grep '## [0-9]' "${CHANGELOG}" | head -n 2 | tail -n 1)
+
+STARTED=false
+
+while IFS= read -r line
+do
+    # Skip lines until the first version header is found
+    if [[ "${STARTED}" == false ]]; then
+        if [[ "${line}" == "${LATEST_VERSION}" ]]; then
+            STARTED=true
+        fi
+        continue
+    fi
+
+    # Stop reading after we see the stopping point
+    if [[ "${line}" == "${STOP_VERSION}" ]]; then
+        break
+    fi
+
+    # Append each line between the two onto the release notes
+    echo -e "${line}" >> "${OUTPUT}"
+
+done < "${CHANGELOG}"
+
+# Delete all leading blank lines at top of file
+sed -i.bak '/./,$!d' "${OUTPUT}"
+rm "${OUTPUT}.bak"


### PR DESCRIPTION
## What changed?

This PR adds a new Github Actions workflow for publishing to NuGet, and to create a Github Release on this repository. The workflow currently is an on-tag action, but may be adjusted to auto-run on every merged commit to `main` if I can get the logic to not be horrific for that.