### PR TITLE
docs: Update DocFX config for GH Pages publishing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OPA ASP.NET Core SDK
 
 > [!IMPORTANT]
-> The documentation for this SDK lives at [https://docs.styra.com/sdk](https://docs.styra.com/sdk), with reference documentation available at [https://styrainc.github.io/opa-aspnetcore/docs](https://styrainc.github.io/opa-aspnetcore/docs)
+> The documentation for this SDK lives at [https://docs.styra.com/sdk](https://docs.styra.com/sdk), with reference documentation available at [https://styrainc.github.io/opa-aspnetcore/](https://styrainc.github.io/opa-aspnetcore/)
 
 You can use the Styra OPA ASP.NET Core SDK to connect [Open Policy Agent](https://www.openpolicyagent.org/) and [Enterprise OPA](https://www.styra.com/enterprise-opa/) deployments to your [ASP.NET Core](https://github.com/dotnet/aspnetcore) applications using the included [Middleware](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/middleware/?view=aspnetcore-8.0) implementation.
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -11,7 +11,8 @@
       },
       {
         "files": [
-          "README.md"
+          "README.md",
+          "DEVELOPMENT.md"
         ],
         "src": "../"
       }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+---
+_layout: landing
+---
+
+[!INCLUDE [](../README.md)]

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,0 +1,2 @@
+- name: API Reference
+  href: api/


### PR DESCRIPTION
## What changed?

The default DocFX configuration generates just a directory listing at the top-level. To control the "landing page" content, one has to provide an `index.md`, and a `toc.yaml`.

I've borrowed appropriate configs from https://github.com/StyraInc/opa-csharp, which at least in local `docfx` builds seem to render the expected docs site.