### PR TITLE
test: Update to Rego v1 + add explicit `--addr` param for OPA fixture.

### DIFF
--- a/.github/workflows/01_build.yaml
+++ b/.github/workflows/01_build.yaml
@@ -7,6 +7,12 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
 
+# When a new revision is pushed to a PR, cancel all in-progress CI runs for that
+# PR. See https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build
@@ -18,7 +24,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "6.0.x"
+          dotnet-version: "8.x"
       - name: Install dependencies
         run: dotnet restore
       - name: Build
@@ -34,11 +40,14 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "6.0.x"
+          dotnet-version: "8.x"
       - name: Install dependencies
         run: dotnet restore
       - name: Test
         run: dotnet test
+        env:
+          EOPA_LICENSE_TOKEN: ${{ secrets.EOPA_LICENSE_TOKEN }}
+        timeout-minutes: 5
 
   release-reqs-check:
     name: Release requirements check

--- a/test/Styra.Opa.AspNetCore.Tests/EOPAContainerFixture.cs
+++ b/test/Styra.Opa.AspNetCore.Tests/EOPAContainerFixture.cs
@@ -26,11 +26,12 @@ public class EOPAContainerFixture : IAsyncLifetime
           // Bind port 8181 of the container to a random port on the host.
           .WithPortBinding(8181, true)
           .WithCommand(startupCommand)
+          // Debugging aid, helpful if the Rego files have syntax errors.
+          .WithOutputConsumer(Consume.RedirectStdoutAndStderrToConsole())
           // Map our policy and data files into the container instance.
           .WithResourceMapping(new DirectoryInfo("testdata"), "/testdata/")
           // Wait until the HTTP endpoint of the container is available.
           .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPort(8181).ForPath("/health")))
-          //.WithOutputConsumer(Consume.RedirectStdoutAndStderrToConsole()) // DEBUG
           // Build the container configuration.
           .Build();
 

--- a/test/Styra.Opa.AspNetCore.Tests/OPAContainerFixture.cs
+++ b/test/Styra.Opa.AspNetCore.Tests/OPAContainerFixture.cs
@@ -15,7 +15,7 @@ public class OPAContainerFixture : IAsyncLifetime
             "testdata/simple/policy.rego",
             "testdata/simple/system.rego",
         };
-        string[] opaCmd = { "run", "--server" };
+        string[] opaCmd = { "run", "--server", "--addr=0.0.0.0:8181" };
         var startupCommand = new List<string>().Concat(opaCmd).Concat(startupFiles).ToArray();
 
         // Create a new instance of a container.
@@ -24,6 +24,8 @@ public class OPAContainerFixture : IAsyncLifetime
           // Bind port 8181 of the container to a random port on the host.
           .WithPortBinding(8181, true)
           .WithCommand(startupCommand)
+          // Debugging aid, helpful if the Rego files have syntax errors.
+          .WithOutputConsumer(Consume.RedirectStdoutAndStderrToConsole())
           // Map our policy and data files into the container instance.
           .WithResourceMapping(new DirectoryInfo("testdata"), "/testdata/")
           // Wait until the HTTP endpoint of the container is available.
@@ -34,6 +36,10 @@ public class OPAContainerFixture : IAsyncLifetime
         // Start the container.
         await container.StartAsync()
             .ConfigureAwait(false);
+        // DEBUG:
+        // var (stderr, stdout) = await container.GetLogsAsync(default);
+        // Console.WriteLine("STDERR: {0}", stderr);
+        // Console.WriteLine("STDOUT: {0}", stdout);
         _container = container;
     }
     public async Task DisposeAsync()

--- a/test/Styra.Opa.AspNetCore.Tests/testdata/simple/policy.rego
+++ b/test/Styra.Opa.AspNetCore.Tests/testdata/simple/policy.rego
@@ -1,5 +1,7 @@
 package policy
 
+import rego.v1
+
 echo := {
     "decision": true,
     "context": {

--- a/test/Styra.Opa.AspNetCore.Tests/testdata/simple/system.rego
+++ b/test/Styra.Opa.AspNetCore.Tests/testdata/simple/system.rego
@@ -1,11 +1,13 @@
 package system
 
+import rego.v1
+
 # This is used to exercise the default query functionality.
 
 msg := "this is the default path"
 
-main := x {
+main := x if {
     x := {"msg": msg, "echo": input}
-} else {
+} else if {
     x := {"msg": msg}
 }


### PR DESCRIPTION
## What changed?

This PR updates the test policies for the Rego v1 syntax, and adds a missing `--addr` parameter for the OPA test fixture that was causing the container to hang on startup.

The hang was caused by the testcontainer health check against port 8181 never succeeding.

Once this PR merges, it should unblock the #26 Dependabot PR that's been error-ing.

EDIT: One of the things broken as well was upgrading the `rule { rule body... } else { rule body...}` syntax to have `if`'s after *both* the rule name and `else`. The lack of useful feedback from the OPA container (and the fact that logs didn't become visible until *after* the container *successfully* starts) made debugging this much more confusing than it needed to be. I've added a log dumping setting, so that at least syntax errors will show up in the logs.