### PR TITLE
ci: Add zizmor linting for GH Actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,12 @@ updates:
       - "/test"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7

--- a/.github/workflows/manual_publish_nuget_pkg.yaml
+++ b/.github/workflows/manual_publish_nuget_pkg.yaml
@@ -7,7 +7,9 @@ on:
 
 permissions:
   contents: read
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -16,14 +18,16 @@ env:
 
 jobs:
   manual-build-and-publish:
+    name: Manually Build and Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Get all history for automatic versioning
+          persist-credentials: false
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: "8.0.x"
 
@@ -44,11 +48,13 @@ jobs:
         shell: pwsh
 
       - name: Pack
-        run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }} --no-build
+        run: dotnet pack --configuration Release --output "$NuGetDirectory" --no-build
 
       - name: Publish NuGet package
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
-          foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Filter *.nupkg)) {
-            dotnet nuget push $file --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          foreach($file in (Get-ChildItem "$env:NuGetDirectory" -Filter *.nupkg)) {
+            dotnet nuget push $file --api-key "$env:NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
           }
         shell: pwsh

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -7,7 +7,9 @@ on:
 permissions:
   contents: read
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -16,17 +18,19 @@ env:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Tune GitHub-hosted runner network
-        uses: smorimoto/tune-github-hosted-runner-network@v1
+        uses: smorimoto/tune-github-hosted-runner-network@bb252dcb5c8609a31087e7993daa086f5a1c0069 # v1.0.0
 
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Get all history for automatic versioning
+          persist-credentials: false
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: "8.0.x"
 
@@ -40,10 +44,10 @@ jobs:
         run: dotnet test --no-restore --verbosity normal
 
       - name: Pack
-        run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }} --no-build
-  
+        run: dotnet pack --configuration Release --output "$NuGetDirectory" --no-build
+
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: artifacts
@@ -55,40 +59,46 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Tune GitHub-hosted runner network
-        uses: smorimoto/tune-github-hosted-runner-network@v1
+        uses: smorimoto/tune-github-hosted-runner-network@bb252dcb5c8609a31087e7993daa086f5a1c0069 # v1.0.0
 
       - name: Check out code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Download release binaries
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: artifacts*
           merge-multiple: true
           path: ${{ env.NuGetDirectory }}
 
       - name: Publish NuGet package
-        run: ./scripts/publish-nuget.sh "${{ env.NuGetDirectory }}" "${{ secrets.NUGET_API_KEY }}"
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: ./scripts/publish-nuget.sh "$NuGetDirectory" "$NUGET_API_KEY"
 
   github-release:
     name: Push Github Release
     needs: [build]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # Needed to create GitHub releases
     steps:
       - name: Tune GitHub-hosted runner network
-        uses: smorimoto/tune-github-hosted-runner-network@v1
+        uses: smorimoto/tune-github-hosted-runner-network@bb252dcb5c8609a31087e7993daa086f5a1c0069 # v1.0.0
 
       - name: Check out code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set TAG_NAME in Environment
         # Subsequent steps will be have the computed tag name
         run: echo "TAG_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Download release binaries
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: artifacts*
           merge-multiple: true
@@ -98,4 +108,4 @@ jobs:
         env:
           # Required for the GitHub CLI
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./scripts/github-release.sh --asset-dir=${{ env.NuGetDirectory }} --tag=${TAG_NAME}
+        run: ./scripts/github-release.sh --asset-dir="$NuGetDirectory" --tag="$TAG_NAME"

--- a/.github/workflows/pr-release-check.yaml
+++ b/.github/workflows/pr-release-check.yaml
@@ -1,0 +1,82 @@
+name: Release Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: 'Base branch to compare against (e.g. main)'
+        required: true
+        default: 'main'
+  pull_request: {}
+
+# When a new revision is pushed to a PR, cancel all in-progress CI runs for that
+# PR. See https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  release-check:
+    name: Release version check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0  # Fetch full history to access all commits
+          persist-credentials: false
+
+      - name: Check for release commits
+        id: check-release
+        env:
+          BASE_REF: ${{ inputs.base_ref || github.base_ref }}
+        run: |
+          RESULT=$(./scripts/get-release-from-commits.sh "origin/$BASE_REF" "HEAD")
+          echo "Release commits detected: $RESULT"
+          if [ -n "$RESULT" ]; then
+            echo "result=true" >> $GITHUB_OUTPUT
+            echo "commit_version=$RESULT" >> $GITHUB_OUTPUT
+          else
+            echo "result=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get CHANGELOG version
+        if: steps.check-release.outputs.result == 'true'
+        id: changelog
+        run: |
+          CHANGELOG_VERSION=$(grep -o -E '## [0-9.]+' CHANGELOG.md | head -n 1 | sed 's/## //' | grep -E '^[0-9.]+$' || echo "invalid")
+          echo "version=$CHANGELOG_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Get csproj version
+        if: steps.check-release.outputs.result == 'true'
+        id: csproj
+        run: |
+          CSPROJ_VERSION=$(./scripts/get-csproj-version.sh "src/OpenPolicyAgent.Opa.AspNetCore/OpenPolicyAgent.Opa.AspNetCore.csproj")
+          echo "version=$CSPROJ_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Verify release versions match
+        if: steps.check-release.outputs.result == 'true'
+        env:
+          COMMIT_VERSION: ${{ steps.check-release.outputs.commit_version }}
+          CHANGELOG_VERSION: ${{ steps.changelog.outputs.version }}
+          CSPROJ_VERSION: ${{ steps.csproj.outputs.version }}
+        run: |
+          echo "ℹ️ Release Commit Detected"
+          echo ""
+          echo "Here are the latest versions reported from the places the release workflows will use:"
+          echo ""
+          echo "| Source | Version |"
+          echo "| --- | --- |"
+          echo "| Commit matching \`^Release .*\` | $COMMIT_VERSION |"
+          echo "| \`CHANGELOG.md\` | $CHANGELOG_VERSION |"
+          echo "| \`src/OpenPolicyAgent.Opa.AspNetCore/OpenPolicyAgent.Opa.AspNetCore.csproj\` | $CSPROJ_VERSION |"
+          echo ""
+
+          if [ "$COMMIT_VERSION" != "$CHANGELOG_VERSION" ] || [ "$COMMIT_VERSION" != "$CSPROJ_VERSION" ]; then
+            echo "❌ Version mismatch detected! All sources must agree before creating a release." >&2
+            exit 1
+          fi
+
+          echo "✅ All version sources agree: $COMMIT_VERSION"

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -10,9 +10,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  actions: read
-  pages: write
-  id-token: write
+  actions: read # needed to download workflow artifacts
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -26,6 +24,10 @@ concurrency:
 
 jobs:
   publish-docs:
+    name: Publish Docs
+    permissions:
+      pages: write # Needed to publish to GitHub Pages
+      id-token: write # Needed for OIDC authentication to deploy pages
     env:
       GH_PAGES_URL: https://open-policy-agent.github.io/opa-aspnetcore
     environment:
@@ -34,10 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Dotnet Setup
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 8.x
 
@@ -45,10 +49,10 @@ jobs:
       - run: docfx docs/docfx.json
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           # Upload entire repository
           path: "docs/_site"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -16,100 +16,19 @@ concurrency:
 
 
 jobs:
-  release-check:
-    name: Release version bump check
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Tune GitHub-hosted runner network
-        uses: smorimoto/tune-github-hosted-runner-network@v1
-
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0  # Fetch full history to access all commits
-
-      - name: Check for release commits
-        id: check-release
-        run: |
-          RESULT=$(./scripts/get-release-from-commits.sh "origin/${{ github.base_ref }}" "origin/${{ github.head_ref }}")
-          echo "Release commits detected: $RESULT"
-          if [ -n $RESULT ]; then
-            echo "result=true" >> $GITHUB_OUTPUT
-          else
-            echo "result=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Post or update warning comment (release commit detected)
-        if: steps.check-release.outputs.result == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          MARKER: "<!-- release-commit-warning -->"
-        run: |
-          # Get latest version from CHANGELOG.md:
-          CHANGELOG_VERSION=$(grep -o -E '## [0-9.]+' CHANGELOG.md | head -n 1 | sed 's/## //')
-
-          # Get version from main csproj:
-          CSPROJ_VERSION=$(./scripts/get-csproj-version.sh "src/OpenPolicyAgent.Opa.AspNetCore/OpenPolicyAgent.Opa.AspNetCore.csproj")
-
-          # Release commit version:
-          COMMIT_VERSION=$(./scripts/get-release-from-commits.sh "origin/${{ github.base_ref }}" "origin/${{ github.head_ref }}")
-
-          COMMENT=$(mktemp)
-          echo "ℹ️ **Release Commit Detected**"                                                        >> "$COMMENT"
-          echo ""                                                                                      >> "$COMMENT"
-          echo "This PR contains commit(s) that match the case-insensitive regex \`^Release .*\`"      >> "$COMMENT"
-          echo ""                                                                                      >> "$COMMENT"
-          echo "Here are the latest versions reported from the places the release workflows will use:" >> "$COMMENT"
-          echo ""                                                                                      >> "$COMMENT"
-          echo "| Source | Version |"                                                                  >> "$COMMENT"
-          echo "| --- | --- |"                                                                         >> "$COMMENT"
-          echo "| Commit matching \`^Release .*\` | $COMMIT_VERSION |"                                 >> "$COMMENT"
-          echo "| \`CHANGELOG.md\` | $CHANGELOG_VERSION |"                                             >> "$COMMENT"
-          echo "| \`src/OpenPolicyAgent.Opa.AspNetCore/OpenPolicyAgent.Opa.AspNetCore.csproj\` | $CSPROJ_VERSION |"          >> "$COMMENT"
-
-          echo "Posting or updating release warning comment."
-          export COMMENT_BODY="$(cat "$COMMENT")"
-          ./scripts/release-pr-comment.sh "$REPO" "$PR_NUMBER" "$MARKER"
-
-      - name: Update warning comment if present (no release commit)
-        if: steps.check-release.outputs.result != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          MARKER: "<!-- release-commit-warning -->"
-          COMMENT_BODY: |
-            ℹ️ A release commit was detected in earlier versions of this PR.
-
-            The current PR commits do not appear to be a release.
-        run: |
-          EXISTING_COMMENT=$(gh api repos/$REPO/issues/$PR_NUMBER/comments \
-              --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1) || {
-              echo "Error: Failed to fetch existing comments" >&2
-              exit 2
-          }
-
-          if [ -n "$EXISTING_COMMENT" ]; then
-            echo "Updating release warning comment."
-            ./scripts/release-pr-comment.sh "$REPO" "$PR_NUMBER" "$MARKER"
-          else
-            echo "No release warning comment found."
-          fi
-
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Tune GitHub-hosted runner network
-        uses: smorimoto/tune-github-hosted-runner-network@v1
+        uses: smorimoto/tune-github-hosted-runner-network@bb252dcb5c8609a31087e7993daa086f5a1c0069 # v1.0.0
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: "8.0.x"
 
@@ -124,12 +43,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Tune GitHub-hosted runner network
-        uses: smorimoto/tune-github-hosted-runner-network@v1
+        uses: smorimoto/tune-github-hosted-runner-network@bb252dcb5c8609a31087e7993daa086f5a1c0069 # v1.0.0
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: "8.0.x"
 
@@ -139,3 +60,14 @@ jobs:
       - name: Test
         run: dotnet test
         timeout-minutes: 5
+
+  gh-actions-lint:
+    name: Github Actions Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/scripts/get-release-from-commits.sh
+++ b/scripts/get-release-from-commits.sh
@@ -46,7 +46,7 @@ fi
 
 # Check for release pattern and extract version.
 VERSION=$(echo "$COMMITS" | grep -E -i "$PATTERN" | head -n 1 | grep -E -o '[0-9.]+') || {
-    echo "No matches found."
+    echo "No matches found." >&2
     exit 0
 }
 


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

This commit adds the [zizmor](https://docs.zizmor.sh/) static analysis tool for Github Actions to our CI workflow, and fixes all found issues for our workflows.

We have also changed our release version detection job to require far less elevated permissions.

### :athletic_shoe: How to test

 - Do the tests still pass?

### :chains: Related Resources

