### PR TITLE
test: Fix dependency Dependabot missed, fix deprecations.

### DIFF
--- a/test/OpenPolicyAgent.Opa.AspNetCore.Tests/EOPAContainerFixture.cs
+++ b/test/OpenPolicyAgent.Opa.AspNetCore.Tests/EOPAContainerFixture.cs
@@ -19,8 +19,7 @@ public class EOPAContainerFixture : IAsyncLifetime
         var startupCommand = new List<string>().Concat(opaCmd).Concat(startupFiles).ToArray();
 
         // Create a new instance of a container.
-        var container = new ContainerBuilder()
-          .WithImage("ghcr.io/open-policy-agent/eopa:latest")
+        var container = new ContainerBuilder("ghcr.io/open-policy-agent/eopa:latest")
           .WithEnvironment("EOPA_LICENSE_TOKEN", Environment.GetEnvironmentVariable("EOPA_LICENSE_TOKEN"))
           .WithEnvironment("EOPA_LICENSE_KEY", Environment.GetEnvironmentVariable("EOPA_LICENSE_KEY"))
           // Bind port 8181 of the container to a random port on the host.

--- a/test/OpenPolicyAgent.Opa.AspNetCore.Tests/OPAContainerFixture.cs
+++ b/test/OpenPolicyAgent.Opa.AspNetCore.Tests/OPAContainerFixture.cs
@@ -19,8 +19,7 @@ public class OPAContainerFixture : IAsyncLifetime
         var startupCommand = new List<string>().Concat(opaCmd).Concat(startupFiles).ToArray();
 
         // Create a new instance of a container.
-        var container = new ContainerBuilder()
-          .WithImage("openpolicyagent/opa:latest")
+        var container = new ContainerBuilder("openpolicyagent/opa:latest")
           // Bind port 8181 of the container to a random port on the host.
           .WithPortBinding(8181, true)
           .WithCommand(startupCommand)

--- a/test/OpenPolicyAgent.Opa.AspNetCore.Tests/OpenPolicyAgent.Opa.AspNetCore.Tests.csproj
+++ b/test/OpenPolicyAgent.Opa.AspNetCore.Tests/OpenPolicyAgent.Opa.AspNetCore.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.27" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Testcontainers" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

Dependabot did not upgrade the test `csproj` at the same time it bumped the main source `csproj` file. This resulted in a "downgrade detected" error message when trying to run `dotnet build`.

### :athletic_shoe: How to test

 - Does our CI work again? 😅 

### :chains: Related Resources

